### PR TITLE
Fix port redirection in readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -87,7 +87,7 @@ Then you would serve up the terrain data using Cesium as per the general usage
 instructions above:
 
 ```sh
-docker run -p 8080:80 -v /data/docker/tilesets/terrain:/data/tilesets/terrain \
+docker run -p 8080:8000 -v /data/docker/tilesets/terrain:/data/tilesets/terrain \
     geodata/cesium-terrain-server 
 ```
 


### PR DESCRIPTION
Not sure how or why but the readme in https://hub.docker.com/r/geodata/cesium-terrain-server/ is not correct, it should be port 8000, not 80.