### PR TITLE
Default tileset URL in template is wrong

### DIFF
--- a/docker/root-fs/var/www/cesium/index.html
+++ b/docker/root-fs/var/www/cesium/index.html
@@ -21,7 +21,7 @@
   <script>
     var viewer = new Cesium.Viewer('cesiumContainer');
     var terrainProvider = new Cesium.CesiumTerrainProvider({
-        url : '/tilesets/terrain/test'
+        url : '/tilesets/test'
     });
     viewer.scene.terrainProvider = terrainProvider;
   </script>


### PR DESCRIPTION
As per this comment:
https://github.com/geo-data/cesium-terrain-server/issues/8#issuecomment-256295584
The file bundled with the docker image is just not pointing to the right URL. It is a pain to just edit that, so it should be fixed here instead.
Also, what would be best would be to have a URL parameter instead of hardcoded "test"